### PR TITLE
Added notification on upgrades if some are available.

### DIFF
--- a/app/components/upgrade-display.js
+++ b/app/components/upgrade-display.js
@@ -14,7 +14,18 @@ export default Component.extend({
 
   actions: {
     async buy() {
-      await this.game.buyUpgrade(this.model)
+      this.model.set('isActive', true)
+      await this.model.save()
+      if (this.model.manaCost > 0) {
+        this.game.universe.set('mana', this.game.universe.mana - this.model.manaCost)
+      }
+      if (this.model.moneyCost > 0) {
+        this.game.universe.set('money', this.game.universe.money - this.model.moneyCost)
+      }
+      if (this.model.scienceCost > 0) {
+        this.game.universe.set('science', this.game.universe.science - this.model.scienceCost)
+      }
+      await this.game.universe.save()
       await this.game.checkAchievements()
     },
     async debugToggle() {

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -1,4 +1,6 @@
 import Controller from '@ember/controller';
+import { filterBy } from '@ember/object/computed';
 
 export default Controller.extend({
+  buyableUpgrades: filterBy('game.upgrades', 'canBuy'),
 });

--- a/app/models/upgrade.js
+++ b/app/models/upgrade.js
@@ -1,7 +1,6 @@
 import DS from 'ember-data';
 const { Model, attr } = DS;
 import { computed } from '@ember/object';
-import { not } from '@ember/object/computed';
 
 export default Model.extend({
   name: attr('string', {defaultValue: ''}),

--- a/app/models/upgrade.js
+++ b/app/models/upgrade.js
@@ -1,6 +1,7 @@
 import DS from 'ember-data';
-import { computed } from '@ember/object';
 const { Model, attr } = DS;
+import { computed } from '@ember/object';
+import { not } from '@ember/object/computed';
 
 export default Model.extend({
   name: attr('string', {defaultValue: ''}),
@@ -12,11 +13,12 @@ export default Model.extend({
   moneyCost: 0,
   scienceCost: 0,
 
-  cannotBuy: computed('game.universe.{mana,money,science}',
+  canBuy: computed('isActive', 'game.universe.{mana,money,science}',
                       'manaCost', 'moneyCost', 'scienceCost', function() {
-    return (this.manaCost > this.game.universe.mana
-        ||  this.moneyCost > this.game.universe.money
-        ||  this.scienceCost > this.game.universe.science
+    return !this.isActive
+        && (this.manaCost <= this.game.universe.mana
+        &&  this.moneyCost <= this.game.universe.money
+        &&  this.scienceCost <= this.game.universe.science
     )
   }),
 });

--- a/app/services/game.js
+++ b/app/services/game.js
@@ -183,7 +183,7 @@ export default Service.extend({
   },
 
   async buyUpgrade(upgrade) {
-    if (! upgrade.cannotBuy && ! upgrade.isActive) {
+    if (upgrade.canBuy) {
       upgrade.set('isActive', true)
       await upgrade.save()
       if (upgrade.manaCost > 0) {

--- a/app/services/game.js
+++ b/app/services/game.js
@@ -182,23 +182,6 @@ export default Service.extend({
     await this.checkAchievements()
   },
 
-  async buyUpgrade(upgrade) {
-    if (upgrade.canBuy) {
-      upgrade.set('isActive', true)
-      await upgrade.save()
-      if (upgrade.manaCost > 0) {
-        this.universe.set('mana', this.universe.mana - upgrade.manaCost)
-      }
-      if (upgrade.moneyCost > 0) {
-        this.universe.set('money', this.universe.money - upgrade.moneyCost)
-      }
-      if (upgrade.scienceCost > 0) {
-        this.universe.set('science', this.universe.science - upgrade.scienceCost)
-      }
-      await this.universe.save()
-    }
-  },
-
   async checkAchievements() {
     for (var achievement of this.achievements.values()) {
       if (! achievement.isActive && achievement.condition) {

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -24,13 +24,16 @@
       {{#link-to "templates" class="nav-link"}}
         Templates
         {{#if game.rebirthPoints}}
-          <DisplayValue @class="badge badge-pill badge-secondary" @type={{game.rebirthPointsType}} @value={{game.rebirthPoints}} />
+          <DisplayValue @class="badge badge-pill badge-primary" @type={{game.rebirthPointsType}} @value={{game.rebirthPoints}} />
         {{/if}}
       {{/link-to}}
     </li>
     <li class="nav-item">
       {{#link-to "upgrades" class="nav-link"}}
         Upgrades
+        {{#if buyableUpgrades}}
+          <span class="badge badge-pill badge-primary">{{buyableUpgrades.length}}</span>
+        {{/if}}
       {{/link-to}}
     </li>
     <li class="nav-item">

--- a/app/templates/components/upgrade-display.hbs
+++ b/app/templates/components/upgrade-display.hbs
@@ -13,7 +13,7 @@
         </button>
       {{/if}}
       {{#if (not model.isActive)}}
-        <button type="button" class="btn btn-primary" disabled={{model.cannotBuy}} onclick={{action "buy"}}>
+        <button type="button" class="btn btn-primary" disabled={{not model.canBuy}} onclick={{action "buy"}}>
           Buy for
           {{#if model.manaCost}}
             <DisplayValue @type="mana" @value={{model.manaCost}} />

--- a/tests/integration/components/upgrade-display-test.js
+++ b/tests/integration/components/upgrade-display-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { click, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import resetStorages from 'ember-local-storage/test-support/reset-storage';
 
@@ -47,5 +47,24 @@ module('Integration | Component | upgrade-display', function(hooks) {
     `);
 
     assert.ok(this.element)
+  });
+
+  test('buyUpgrade', async function(assert) {
+    let store = this.owner.lookup('service:store');
+    let game = this.owner.lookup('service:game');
+    store.createRecord('universe', {mana: 5000})
+    await game.load()
+    let clickPower = game.getUpgrade('Click Power')
+    this.set('upgrade', clickPower)
+    assert.ok(clickPower.canBuy)
+    assert.notOk(this.upgrade.isActive)
+
+    await render(hbs`<UpgradeDisplay @model={{this.upgrade}}/>`);
+
+    // Click the "Buy" button
+    await click('.btn.btn-primary')
+
+    assert.ok(this.upgrade.isActive)
+    assert.notEqual(game.universe.mana, 5000)
   });
 });

--- a/tests/unit/models/upgrade-test.js
+++ b/tests/unit/models/upgrade-test.js
@@ -38,7 +38,7 @@ module('Unit | Model | upgrade', function(hooks) {
     store.createRecord('universe', {mana: 0})
     let upgrade = store.createRecord('upgrade', {name: 'Test only upgrade', manaCost: 12})
     await game.load()
-    assert.ok(upgrade.cannotBuy)
+    assert.notOk(upgrade.canBuy)
   });
 
   test('Can buy', async function(assert) {
@@ -47,6 +47,6 @@ module('Unit | Model | upgrade', function(hooks) {
     store.createRecord('universe', {mana: 12})
     let upgrade = store.createRecord('upgrade', {name: 'Test only upgrade', manaCost: 12})
     await game.load()
-    assert.notOk(upgrade.cannotBuy)
+    assert.ok(upgrade.canBuy)
   });
 });

--- a/tests/unit/services/game-test.js
+++ b/tests/unit/services/game-test.js
@@ -105,20 +105,6 @@ module('Unit | Service | game', function(hooks) {
     assert.equal(up.isActive, true)
   });
 
-  test('buyUpgrade', async function(assert) {
-    let store = this.owner.lookup('service:store');
-    let game = this.owner.lookup('service:game');
-    store.createRecord('universe', {mana: 5, money: 5, science: 5})
-    await game.load()
-    let upgrade = game.getUpgrade('Spontaneous Generation') //Should cost 1 mana
-    assert.ok(upgrade.canBuy)
-    await game.buyUpgrade(upgrade)
-    assert.ok(upgrade.isActive)
-    assert.equal(game.universe.mana, 4)
-    assert.equal(game.universe.money, 5)
-    assert.equal(game.universe.science, 5)
-  });
-
   test('checkAchievements', async function(assert) {
     let store = this.owner.lookup('service:store');
     let game = this.owner.lookup('service:game');

--- a/tests/unit/services/game-test.js
+++ b/tests/unit/services/game-test.js
@@ -111,7 +111,7 @@ module('Unit | Service | game', function(hooks) {
     store.createRecord('universe', {mana: 5, money: 5, science: 5})
     await game.load()
     let upgrade = game.getUpgrade('Spontaneous Generation') //Should cost 1 mana
-    assert.notOk(upgrade.cannotBuy)
+    assert.ok(upgrade.canBuy)
     await game.buyUpgrade(upgrade)
     assert.ok(upgrade.isActive)
     assert.equal(game.universe.mana, 4)

--- a/tests/unit/utils/computed-test.js
+++ b/tests/unit/utils/computed-test.js
@@ -28,17 +28,15 @@ module('Unit | Utility | computed', function(hooks) {
   });
 
   test('upgrade | Computed macro', async function(assert) {
-    let store = this.owner.lookup('service:store');
     let game = this.owner.lookup('service:game');
-    store.createRecord('universe', {mana: 5, money: 5, science: 5})
     await game.load()
     let up = game.getUpgrade('Spontaneous Generation') //Should cost 1 mana
     let empire = game.empire
     defineProperty(empire, 'upgradeOK', upgrade('Spontaneous Generation')),
-    assert.ok(up.canBuy)
+    assert.notOk(up.isActive)
     assert.notOk(empire.upgradeOK)
 
-    await game.buyUpgrade(up)
+    up.set('isActive', true)
 
     assert.ok(up.isActive)
     assert.ok(empire.upgradeOK)

--- a/tests/unit/utils/computed-test.js
+++ b/tests/unit/utils/computed-test.js
@@ -35,7 +35,7 @@ module('Unit | Utility | computed', function(hooks) {
     let up = game.getUpgrade('Spontaneous Generation') //Should cost 1 mana
     let empire = game.empire
     defineProperty(empire, 'upgradeOK', upgrade('Spontaneous Generation')),
-    assert.notOk(up.cannotBuy)
+    assert.ok(up.canBuy)
     assert.notOk(empire.upgradeOK)
 
     await game.buyUpgrade(up)


### PR DESCRIPTION
Notification is not (yet?) disabled when visiting upgrades, but that's better than before.
I also used this commit to inverse cannotBuy into canBuy, to avoid double negatives.

Closes https://github.com/DainDwarf/IncrementalEmpire/issues/89