### PR TITLE
Spell component

### DIFF
--- a/app/components/empire-building.js
+++ b/app/components/empire-building.js
@@ -30,14 +30,9 @@ export default Component.extend({
     return this.building.workers + "/" + (this.building.maxWorkers*this.building.qty)
   }),
 
-  isHolyBuildingDisabled: computed('empire.{spellPoints,dead}', 'building.spellCost', function() {
-    return this.empire.dead || (this.empire.spellPoints < this.building.spellCost)
-  }),
   _holyBuildingUpgrade: upgrade('Holy Building'),
-  isHolyBuildingAvailable: computed('empire.type', '_holyBuildingUpgrade', function() {
-    return this.empire.type == "religious"
-      &&   this._holyBuildingUpgrade
-      &&   this.building.spellCost > 0
+  isHolyBuildingAvailable: computed('_holyBuildingUpgrade', 'building.spellCost', function() {
+    return this._holyBuildingUpgrade && this.building.spellCost > 0
   }),
 
   // Need at least one button available to give a footer in long display.
@@ -57,10 +52,7 @@ export default Component.extend({
   actions: {
     async holyBuilding() {
       this.building.set('qty', this.building.qty+1)
-      this.empire.set('spellPoints', this.empire.spellPoints - this.building.spellCost)
-      this.empire.incrementProperty('spellCount')
       await this.building.save()
-      await this.empire.save()
     },
     async build(qty) {
       let change = qty - this.building.pending

--- a/app/components/empire-building.js
+++ b/app/components/empire-building.js
@@ -50,8 +50,8 @@ export default Component.extend({
   isLongDisplay: alias('building.isLongDisplay'),
 
   actions: {
-    async holyBuilding() {
-      this.building.set('qty', this.building.qty+1)
+    async holyBuilding(qty) {
+      this.building.set('qty', this.building.qty+qty)
       await this.building.save()
     },
     async build(qty) {

--- a/app/components/empire-spell.js
+++ b/app/components/empire-spell.js
@@ -1,0 +1,31 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+
+export default Component.extend({
+  empire: undefined,
+  tagName: 'span',
+  spellCost: 1,
+  visible: true,   // Hide the spell even on religious empires. Usually links to an upgrade.
+  disabled: false, // Disable the spell (normal cases of spellCost/empire dead are already handled)
+  outputType: '',
+  outputValue: '',
+  onSpell() {}, //Action to trigger when casting the spell
+
+  _visible: computed('empire.type', 'visible', function() {
+    return this.empire.type == "religious" && this.visible
+  }),
+
+  _disabled: computed('disabled', 'empire.{dead,spellPoints}', 'spellCost', function() {
+    return this.empire.dead || this.empire.spellPoints < this.spellCost || this.disabled
+  }),
+
+  actions: {
+    async castSpell() {
+      this.empire.decrementProperty('spellPoints', this.spellCost)
+      this.empire.incrementProperty('spellCount')
+      await this.empire.save()
+      await this.onSpell()
+      await this.game.checkAchievements()
+    },
+  },
+});

--- a/app/components/empire-spell.js
+++ b/app/components/empire-spell.js
@@ -4,12 +4,14 @@ import { computed } from '@ember/object';
 export default Component.extend({
   empire: undefined,
   tagName: 'span',
-  spellCost: 1,
-  visible: true,   // Hide the spell even on religious empires. Usually links to an upgrade.
-  disabled: false, // Disable the spell (normal cases of spellCost/empire dead are already handled)
-  outputType: '',
-  outputValue: '',
-  onSpell() {}, //Action to trigger when casting the spell
+  spellCost: 1,       // Spell cost of a single spell call.
+  visible: true,      // Hide the spell even on religious empires. Usually links to an upgrade.
+  disabled: false,    // Disable the spell (normal cases of spellCost/empire dead are already handled)
+  outputType: '',     // Type as in DisplayValue component
+  outputValue: '',    // Output value of a single spell call
+  maxOutputValue: undefined,  // If spell output can be limited, limit it there as the limit of output the spell can give at the current time (not the limit overall!)
+  step: '+1',         // Step as in empire assign thingy.
+  onSpell() {},       // Action to trigger when casting the spell
 
   _visible: computed('empire.type', 'visible', function() {
     return this.empire.type == "religious" && this.visible
@@ -19,12 +21,69 @@ export default Component.extend({
     return this.empire.dead || this.empire.spellPoints < this.spellCost || this.disabled
   }),
 
+  // Limit of quantity that can be cast based on spellpoints alone
+  _spellCostQtyMax: computed('spellCost', 'empire.spellPoints', function() {
+    return Math.floor(this.empire.spellPoints/this.spellCost)
+  }),
+  // Limit of quantity that can be cast based on quantity alone
+  _spellOutputQtyMax: computed('maxOutputValue', 'outputValue', function() {
+    if (! this.outputValue || this.maxOutputValue === undefined) {
+      return undefined
+    } else {
+      return Math.ceil(this.maxOutputValue/this.outputValue)
+    }
+  }),
+  _spellQtyMax: computed('_spellCostQtyMax', '_spellOutputQtyMax', function() {
+    if (this._spellOutputQtyMax === undefined) { //No limit from output
+      return this._spellCostQtyMax
+    } else {
+      return Math.min(this._spellCostQtyMax, this._spellOutputQtyMax)
+    }
+  }),
+
+  // Quantity of times the spell will actually be cast
+  qty: computed('step', '_spellQtyMax', function() {
+    let q = 1
+    if (this.step.toUpperCase() == "MAX") {
+      q = this._spellQtyMax
+    } else if (this.step.endsWith('%')) {
+      let percent = parseInt(this.step)/100
+      q = Math.ceil(percent*(this._spellQtyMax))
+    } else {
+      let incr = parseInt(this.step)
+      q = incr
+    }
+    return Math.min(q, this._spellQtyMax)
+  }),
+
+  computedCost: computed('qty', 'spellCost', function() {
+    if (this.qty > 0) {
+      return this.qty*this.spellCost
+    } else {
+      return this.spellCost
+    }
+  }),
+  computedOutput: computed('qty', 'outputValue', function() {
+    if (this.outputValue) {
+      if (this.qty > 0) {
+        return this.qty*this.outputValue
+      } else {
+        return this.outputValue
+      }
+    } else {
+      return false
+    }
+  }),
+
   actions: {
     async castSpell() {
-      this.empire.decrementProperty('spellPoints', this.spellCost)
-      this.empire.incrementProperty('spellCount')
+      let cost = this.computedCost
+      let qty = this.qty
+      let output = this.computedOutput
+      this.empire.decrementProperty('spellPoints', cost)
+      this.empire.incrementProperty('spellCount', qty)
       await this.empire.save()
-      await this.onSpell()
+      await this.onSpell(output)
       await this.game.checkAchievements()
     },
   },

--- a/app/controllers/empire/food.js
+++ b/app/controllers/empire/food.js
@@ -1,15 +1,10 @@
 import Controller from '@ember/controller';
 import { inject as controller } from '@ember/controller';
 import { computed } from '@ember/object';
-import { filter, lt, or } from '@ember/object/computed';
+import { filter } from '@ember/object/computed';
 
 export default Controller.extend({
   empireCtl: controller('empire'),
-  isGenFoodOnCooldown: lt('model.spellPoints', 1),
-  isGenFoodDisabled: or('isGenFoodOnCooldown', 'model.dead', 'empireCtl.isMaxFood'),
-  isGenFoodAvailable: computed('model.type', function() {
-    return this.model.type == "religious"
-  }),
 
   foodStorageBuildings: filter('model.foodStorageBuildings.@each.{isCapital,isEmpireAvailable}',
     b => ! b.isCapital && b.isEmpireAvailable
@@ -28,13 +23,9 @@ export default Controller.extend({
   }),
 
   actions: {
-    async genFood(event) {
-      event.preventDefault();
+    async genFood() {
       this.model.set('food', Math.min(this.model.food + this.empireCtl.ressourceSpellEfficiency, this.model.foodStorage))
-      this.model.set('spellPoints', this.model.spellPoints - 1)
-      this.model.incrementProperty('spellCount')
       await this.model.save()
-      await this.game.checkAchievements()
     },
   },
 });

--- a/app/controllers/empire/food.js
+++ b/app/controllers/empire/food.js
@@ -23,8 +23,8 @@ export default Controller.extend({
   }),
 
   actions: {
-    async genFood() {
-      this.model.set('food', Math.min(this.model.food + this.empireCtl.ressourceSpellEfficiency, this.model.foodStorage))
+    async genFood(qty) {
+      this.model.set('food', Math.min(this.model.food + qty, this.model.foodStorage))
       await this.model.save()
     },
   },

--- a/app/controllers/empire/material.js
+++ b/app/controllers/empire/material.js
@@ -1,17 +1,12 @@
 import Controller from '@ember/controller';
 import { inject as controller } from '@ember/controller';
 import { computed } from '@ember/object';
-import { filter, lt, or } from '@ember/object/computed';
+import { filter } from '@ember/object/computed';
 import { upgrade } from 'incremental-empire/utils/computed';
 
 export default Controller.extend({
   empireCtl: controller('empire'),
-  isGenMaterialOnCooldown: lt('model.spellPoints', 1),
-  isGenMaterialDisabled: or('isGenMaterialOnCooldown', 'model.dead', 'empireCtl.isMaxMaterial'),
   magicAnvilUpgrade: upgrade('Magic Anvil'),
-  isGenMaterialAvailable: computed('model.type', 'magicAnvilUpgrade', function() {
-    return this.model.type == "religious" && this.magicAnvilUpgrade
-  }),
 
   materialStorageBuildings: filter('model.materialStorageBuildings.@each.{isCapital,isEmpireAvailable}',
     b => ! b.isCapital && b.isEmpireAvailable
@@ -30,13 +25,9 @@ export default Controller.extend({
   }),
 
   actions: {
-    async genMaterial(event) {
-      event.preventDefault();
+    async genMaterial() {
       this.model.set('material', Math.min(this.model.material + this.empireCtl.ressourceSpellEfficiency, this.model.materialStorage))
-      this.model.set('spellPoints', this.model.spellPoints - 1)
-      this.model.incrementProperty('spellCount')
       await this.model.save()
-      await this.game.checkAchievements()
     },
   },
 });

--- a/app/controllers/empire/material.js
+++ b/app/controllers/empire/material.js
@@ -25,8 +25,8 @@ export default Controller.extend({
   }),
 
   actions: {
-    async genMaterial() {
-      this.model.set('material', Math.min(this.model.material + this.empireCtl.ressourceSpellEfficiency, this.model.materialStorage))
+    async genMaterial(qty) {
+      this.model.set('material', Math.min(this.model.material + qty, this.model.materialStorage))
       await this.model.save()
     },
   },

--- a/app/controllers/empire/population.js
+++ b/app/controllers/empire/population.js
@@ -1,17 +1,12 @@
 import Controller from '@ember/controller';
 import { inject as controller } from '@ember/controller';
 import { computed } from '@ember/object';
-import { filter, or, lt } from '@ember/object/computed';
+import { filter } from '@ember/object/computed';
 import { upgrade } from 'incremental-empire/utils/computed';
 
 export default Controller.extend({
   empireCtl: controller('empire'),
   genPopUpgrade: upgrade('Spontaneous Generation'),
-  isGenPopulationAvailable: computed('genPopUpgrade', 'model.type', function() {
-    return this.model.type == "religious" && this.genPopUpgrade
-  }),
-  isGenPopulationOnCooldown: lt('model.spellPoints', 5),
-  isGenPopulationDisabled: or('isGenPopulationOnCooldown', 'model.dead', 'empireCtl.isMaxPop'),
 
   populationStorageBuildings: filter('model.populationStorageBuildings.@each.{isCapital,isEmpireAvailable}',
     b => ! b.isCapital && b.isEmpireAvailable
@@ -30,13 +25,9 @@ export default Controller.extend({
   }),
 
   actions: {
-    async genPopulation(event) {
-      event.preventDefault();
+    async genPopulation() {
       this.model.set('population', Math.min(this.model.population + 1, this.model.populationStorage))
-      this.model.set('spellPoints', this.model.spellPoints - 5)
-      this.model.incrementProperty('spellCount')
       await this.model.save()
-      await this.game.checkAchievements()
     },
   },
 });

--- a/app/controllers/empire/population.js
+++ b/app/controllers/empire/population.js
@@ -25,8 +25,8 @@ export default Controller.extend({
   }),
 
   actions: {
-    async genPopulation() {
-      this.model.set('population', Math.min(this.model.population + 1, this.model.populationStorage))
+    async genPopulation(qty) {
+      this.model.set('population', Math.min(this.model.population + qty, this.model.populationStorage))
       await this.model.save()
     },
   },

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -66,3 +66,21 @@ input[type=number] {
   overflow-y: scroll;
   max-height: calc(100vh - 160px);
 }
+
+// Disable some reboot.scss for non-button buttons.
+// See issue https://github.com/DainDwarf/IncrementalEmpire/issues/112
+[type=button] {
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  -webkit-user-select: none; /* webkit (safari, chrome) browsers */
+  -moz-user-select: none; /* mozilla browsers */
+  -khtml-user-select: none; /* webkit (konqueror) browsers */
+  -ms-user-select: none; /* IE10+ */
+}
+
+[type=button][disabled] {
+  cursor: default;
+  pointer-events: none;
+  opacity: $btn-disabled-opacity;
+  @include box-shadow(none);
+}

--- a/app/templates/components/empire-building.hbs
+++ b/app/templates/components/empire-building.hbs
@@ -7,13 +7,9 @@
     {{/if}}
     {{#if (not isLongDisplay)}}
       <span class="float-right">
-        <button type="button"
-                class="btn btn-outline-success mt-1"
-                hidden={{not isHolyBuildingAvailable}}
-                disabled={{isHolyBuildingDisabled}}
-                onclick={{action "holyBuilding"}}>
-          <DisplayValue @tagName="small" @type="magic" @value={{building.spellCost}}/>
-        </button>
+        <EmpireSpell @empire={{empire}} @spellCost={{building.spellCost}}
+                     @visible={{isHolyBuildingAvailable}}
+                     @onSpell={{action "holyBuilding"}}/>
         {{#if canBuild}}
           <DisplayValue @type="material" @value={{building.materialCost}}/>
           <AssignPoint @disabled={{empire.dead}} @tagName="span"
@@ -64,13 +60,12 @@
     </div>
     <div class="card-footer" hidden={{not displayFooter}}>
       <div class="row">
-        <button type="button"
-                class="btn btn-outline-success mt-1 text-nowrap"
-                hidden={{not isHolyBuildingAvailable}}
-                disabled={{isHolyBuildingDisabled}}
-                onclick={{action "holyBuilding"}}>
-          Holy Building <DisplayValue @tagName="small" @type="magic" @value={{building.spellCost}}/>
-        </button>
+        <EmpireSpell @empire={{empire}} @spellCost={{building.spellCost}}
+                     @outputType="building" @outputValue="1"
+                     @visible={{isHolyBuildingAvailable}}
+                     @onSpell={{action "holyBuilding"}}>
+          Holy Building
+        </EmpireSpell>
         {{#if canBuild}}
           <div class="col text-center">
             <span class="text-nowrap">

--- a/app/templates/components/empire-building.hbs
+++ b/app/templates/components/empire-building.hbs
@@ -8,7 +8,8 @@
     {{#if (not isLongDisplay)}}
       <span class="float-right">
         <EmpireSpell @empire={{empire}} @spellCost={{building.spellCost}}
-                     @visible={{isHolyBuildingAvailable}}
+                     @visible={{isHolyBuildingAvailable}} @step={{step}}
+                     @outputType="building" @outputValue="1"
                      @onSpell={{action "holyBuilding"}}/>
         {{#if canBuild}}
           <DisplayValue @type="material" @value={{building.materialCost}}/>
@@ -62,7 +63,7 @@
       <div class="row">
         <EmpireSpell @empire={{empire}} @spellCost={{building.spellCost}}
                      @outputType="building" @outputValue="1"
-                     @visible={{isHolyBuildingAvailable}}
+                     @visible={{isHolyBuildingAvailable}} @step={{step}}
                      @onSpell={{action "holyBuilding"}}>
           Holy Building
         </EmpireSpell>

--- a/app/templates/components/empire-spell.hbs
+++ b/app/templates/components/empire-spell.hbs
@@ -1,0 +1,14 @@
+<button type="button"
+        class="btn btn-outline-success mt-1"
+        hidden={{not _visible}}
+        disabled={{_disabled}}
+        onclick={{action "castSpell"}}>
+  {{yield}}
+  <small>
+    <DisplayValue @type="magic" @value={{spellCost}}/>
+    {{#if outputType}}
+      <FaIcon @icon="arrow-right"/>
+      <DisplayValue @type={{outputType}} @value={{outputValue}}/>
+    {{/if}}
+  </small>
+</button>

--- a/app/templates/components/empire-spell.hbs
+++ b/app/templates/components/empire-spell.hbs
@@ -1,4 +1,4 @@
-<div type="button" role="button" class="btn btn-outline-success mt-1"
+<div type="button" role="button" class="btn btn-outline-success"
         hidden={{not _visible}}
         disabled={{_disabled}}
         onclick={{action "castSpell"}}>

--- a/app/templates/components/empire-spell.hbs
+++ b/app/templates/components/empire-spell.hbs
@@ -5,10 +5,10 @@
         onclick={{action "castSpell"}}>
   {{yield}}
   <small>
-    <DisplayValue @type="magic" @value={{spellCost}}/>
+    <DisplayValue @type="magic" @value={{computedCost}}/>
     {{#if outputType}}
       <FaIcon @icon="arrow-right"/>
-      <DisplayValue @type={{outputType}} @value={{outputValue}}/>
+      <DisplayValue @type={{outputType}} @value={{computedOutput}}/>
     {{/if}}
   </small>
 </button>

--- a/app/templates/components/empire-spell.hbs
+++ b/app/templates/components/empire-spell.hbs
@@ -1,5 +1,4 @@
-<button type="button"
-        class="btn btn-outline-success mt-1"
+<div type="button" role="button" class="btn btn-outline-success mt-1"
         hidden={{not _visible}}
         disabled={{_disabled}}
         onclick={{action "castSpell"}}>
@@ -11,4 +10,4 @@
       <DisplayValue @type={{outputType}} @value={{computedOutput}}/>
     {{/if}}
   </small>
-</button>
+</div>

--- a/app/templates/empire/food.hbs
+++ b/app/templates/empire/food.hbs
@@ -12,18 +12,11 @@
     You will lose some population next turn
   </div>
 {{/if}}
-<button type="button"
-        class="btn btn-outline-success mt-1"
-        hidden={{not isGenFoodAvailable}}
-        disabled={{isGenFoodDisabled}}
-        onclick={{action "genFood"}}>
+<EmpireSpell @empire={{model}} @spellCost="1" @disabled={{empireCtl.isMaxFood}}
+             @outputType="food" @outputValue={{empireCtl.ressourceSpellEfficiency}}
+             @onSpell={{action "genFood"}}>
   Horn of Plenty
-  <small>
-    <DisplayValue @type="magic" @value="1"/>
-    <FaIcon @icon="arrow-right"/>
-    <DisplayValue @type="food" @value={{empireCtl.ressourceSpellEfficiency}}/>
-  </small>
-</button>
+</EmpireSpell>
 {{#if foodStorageBuildings}}
   <hr>
   <h3>Storage</h3>

--- a/app/templates/empire/food.hbs
+++ b/app/templates/empire/food.hbs
@@ -14,6 +14,7 @@
 {{/if}}
 <EmpireSpell @empire={{model}} @spellCost="1" @disabled={{empireCtl.isMaxFood}}
              @outputType="food" @outputValue={{empireCtl.ressourceSpellEfficiency}}
+             @maxOutputValue={{sub model.foodStorage model.food}} @step={{empireCtl.assignValue}}
              @onSpell={{action "genFood"}}>
   Horn of Plenty
 </EmpireSpell>

--- a/app/templates/empire/material.hbs
+++ b/app/templates/empire/material.hbs
@@ -10,6 +10,7 @@
 <EmpireSpell @empire={{model}} @spellCost="1" @disabled={{empireCtl.isMaxMaterial}}
              @visible={{magicAnvilUpgrade}}
              @outputType="material" @outputValue={{empireCtl.ressourceSpellEfficiency}}
+             @maxOutputValue={{sub model.materialStorage model.material}} @step={{empireCtl.assignValue}}
              @onSpell={{action "genMaterial"}}>
   Magic Anvil
 </EmpireSpell>

--- a/app/templates/empire/material.hbs
+++ b/app/templates/empire/material.hbs
@@ -7,18 +7,12 @@
     You generate <DisplayValue @type="material" @value={{model.materialProduction}}/> per turn
   </div>
 {{/if}}
-<button type="button"
-        class="btn btn-outline-success mt-1"
-        hidden={{not isGenMaterialAvailable}}
-        disabled={{isGenMaterialDisabled}}
-        onclick={{action "genMaterial"}}>
+<EmpireSpell @empire={{model}} @spellCost="1" @disabled={{empireCtl.isMaxMaterial}}
+             @visible={{magicAnvilUpgrade}}
+             @outputType="material" @outputValue={{empireCtl.ressourceSpellEfficiency}}
+             @onSpell={{action "genMaterial"}}>
   Magic Anvil
-  <small>
-    <DisplayValue @type="magic" @value="1"/>
-    <FaIcon @icon="arrow-right"/>
-    <DisplayValue @type="material" @value={{empireCtl.ressourceSpellEfficiency}}/>
-  </small>
-</button>
+</EmpireSpell>
 {{#if materialStorageBuildings}}
   <hr>
   <h3>Storage</h3>

--- a/app/templates/empire/population.hbs
+++ b/app/templates/empire/population.hbs
@@ -15,18 +15,12 @@
     You have <DisplayValue @type="worker" @value={{model.availableWorkers}}/>. Fix the situation before begin able to go to next turn.
   </div>
 {{/if}}
-<button type="button"
-        class="btn btn-outline-success mt-1"
-        hidden={{not isGenPopulationAvailable}}
-        disabled={{isGenPopulationDisabled}}
-        onclick={{action "genPopulation"}}>
+<EmpireSpell @empire={{model}} @spellCost="5" @disabled={{empireCtl.isMaxPop}}
+             @visible={{genPopUpgrade}}
+             @outputType="population" @outputValue="1"
+             @onSpell={{action "genPopulation"}}>
   Spontaneous Generation
-  <small>
-    <DisplayValue @type="magic" @value="5" />
-    <FaIcon @icon="arrow-right"/>
-    <DisplayValue @type="population" @value="1" />
-  </small>
-</button>
+</EmpireSpell>
 {{#if populationStorageBuildings}}
   <hr>
   <h3>Storage</h3>

--- a/app/templates/empire/population.hbs
+++ b/app/templates/empire/population.hbs
@@ -18,6 +18,8 @@
 <EmpireSpell @empire={{model}} @spellCost="5" @disabled={{empireCtl.isMaxPop}}
              @visible={{genPopUpgrade}}
              @outputType="population" @outputValue="1"
+             @maxOutputValue={{sub model.populationStorage model.population}}
+             @step={{empireCtl.assignValue}}
              @onSpell={{action "genPopulation"}}>
   Spontaneous Generation
 </EmpireSpell>

--- a/tests/integration/components/empire-spell-test.js
+++ b/tests/integration/components/empire-spell-test.js
@@ -1,0 +1,50 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import resetStorages from 'ember-local-storage/test-support/reset-storage';
+
+module('Integration | Component | empire-spell', function(hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function() {
+    if (window.localStorage) {
+      window.localStorage.clear();
+    }
+    if (window.sessionStorage) {
+      window.sessionStorage.clear();
+    }
+    resetStorages();
+  });
+
+  hooks.afterEach(function() {
+    if (window.localStorage) {
+      window.localStorage.clear();
+    }
+    if (window.sessionStorage) {
+      window.sessionStorage.clear();
+    }
+    resetStorages();
+  });
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+    let game = this.owner.lookup('service:game');
+    await game.load()
+    this.set('empire', game.empire)
+
+    await render(hbs`<EmpireSpell @empire={{this.empire}} />`);
+
+    assert.ok(this.element);
+
+    // Template block usage:
+    await render(hbs`
+      <EmpireSpell @empire={{this.empire}}>
+        template block text
+      </EmpireSpell>
+    `);
+
+    assert.ok(this.element);
+  });
+});

--- a/tests/integration/components/empire-spell-test.js
+++ b/tests/integration/components/empire-spell-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { click, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import resetStorages from 'ember-local-storage/test-support/reset-storage';
 
@@ -46,5 +46,104 @@ module('Integration | Component | empire-spell', function(hooks) {
     `);
 
     assert.ok(this.element);
+  });
+
+  test('Max spell cost', async function(assert) {
+    // Testing that when casting MAX spell, it correctly stops based on spell points
+    let game = this.owner.lookup('service:game');
+    await game.load()
+    this.set('empire', game.empire)
+    // I'm a great wizard!
+    this.set('empire.spellPoints', 100)
+    this.set('empire.maxSpellPoints', 100)
+
+    //Spell will be called 11 times without output of 12
+    this.set('youWish', (qty) => { assert.equal(qty, 11*12) })
+
+    await render(hbs`<EmpireSpell
+        @empire={{this.empire}}
+        @spellCost="9"
+        @outputType="mana"
+        @outputValue="12"
+        @maxOutputValue="9999999"
+        @step="MAX"
+        @onSpell={{action youWish}}
+    />`);
+
+    assert.notOk(this.element.querySelector('div').hasAttribute('disabled'))
+
+    await click('.btn')
+
+    // 1 spell point remaining, spell is disabled
+    assert.equal(game.empire.spellPoints, 1)
+    assert.ok(this.element.querySelector('div').hasAttribute('disabled'))
+  });
+
+  test('Max output value', async function(assert) {
+    // Testing that when casting MAX output, it correctly stops based on max output
+    let game = this.owner.lookup('service:game');
+    await game.load()
+    this.set('empire', game.empire)
+    // I'm a great wizard!
+    this.set('empire.spellPoints', 100)
+    this.set('empire.maxSpellPoints', 100)
+    this.set('maxOutput', 40)
+
+    // Spell will be called 4 times without output of 40
+    // Casting 3 times do not reach the max, so it casts a 4th time, but is limited by the maxOutputValue.
+    this.set('youWish', (qty) => {
+      assert.equal(qty, 40)
+      this.set('maxOutput', this.maxOutput-qty)
+    })
+
+    await render(hbs`<EmpireSpell
+        @empire={{this.empire}}
+        @spellCost="9"
+        @outputType="mana"
+        @outputValue="12"
+        @maxOutputValue={{this.maxOutput}}
+        @step="MAX"
+        @onSpell={{action youWish}}
+    />`);
+
+    assert.notOk(this.element.querySelector('div').hasAttribute('disabled'))
+
+    await click('.btn')
+
+    // Casted 4 times. Yes, I'm so lazy I don't even precompute
+    assert.equal(game.empire.spellPoints, 100-4*9)
+    assert.ok(this.element.querySelector('div').hasAttribute('disabled'))
+  });
+
+  test('Cannot use disabled button', async function(assert) {
+    // Testing that when the button is marked as disabled, we cannot click it
+    let game = this.owner.lookup('service:game');
+    await game.load()
+    this.set('empire', game.empire)
+    // I'm a great wizard!
+    this.set('empire.spellPoints', 100)
+    this.set('empire.maxSpellPoints', 100)
+
+    // This should not be called, as the button is disabled
+    this.set('impossible', () => {
+      assert.ok(false, "The callback should not be called on a disabled spell")
+    })
+
+    await render(hbs`<EmpireSpell
+        @empire={{this.empire}}
+        @spellCost="1"
+        @outputType="mana"
+        @outputValue="999"
+        @step="MAX"
+        @disabled=true
+        @onSpell={{action impossible}}
+    />`);
+
+    assert.ok(this.element.querySelector('div').hasAttribute('disabled'))
+
+    await click('.btn')
+
+    // Since it was not casted, we still have all our spell points
+    assert.equal(game.empire.spellPoints, 100)
   });
 });


### PR DESCRIPTION
This closes three issues on the same PR:
* Added a component for spells
* Use this component to use the "assign" empire dropdown for spells as well in a single place
* Use this component to change from `button` HTML tag into a `type=button`, addressing some css issues from bootstrap itself.